### PR TITLE
feat: add a return type to transaction's cardHashKey function

### DIFF
--- a/src/client/transactions/namespace.ts
+++ b/src/client/transactions/namespace.ts
@@ -6,7 +6,7 @@ import {
   TransactionCaptureOptions,
   TransactionRefundOptions
 } from './options';
-import { Transaction, CalculateInstallmentsAmount } from './responses';
+import { Transaction, CalculateInstallmentsAmount, CardHashKey } from './responses';
 
 declare module 'pagarme' {
   export namespace client {
@@ -23,7 +23,7 @@ declare module 'pagarme' {
 
       function capture(opts: TransactionCaptureOptions): Promise<Transaction>;
 
-      function cardHashKey(opts: any): any;
+      function cardHashKey(opts: any): Promise<CardHashKey>;
 
       function collectPayment(opts: any, body: any): any;
 

--- a/src/client/transactions/responses.ts
+++ b/src/client/transactions/responses.ts
@@ -111,3 +111,10 @@ export interface CalculateInstallmentsAmount {
     [key: string]: Installment;
   };
 }
+
+export interface CardHashKey {
+    date_created: "string",
+    id: number,
+    ip: string,
+    public_key: string,
+}

--- a/src/client/transactions/responses.ts
+++ b/src/client/transactions/responses.ts
@@ -113,8 +113,12 @@ export interface CalculateInstallmentsAmount {
 }
 
 export interface CardHashKey {
+    /** Momento de criação da chave pública. */
     date_created: "string",
+    /** id retornado e que será utilizado para compor o card_hash, logo, é importante que você o reserve. */
     id: number,
+    /** IP de onde a request foi originada. */
     ip: string,
+    /** Chave pública utilizada para criptografar os dados do cartão. */
     public_key: string,
 }


### PR DESCRIPTION
## O que esse PR faz? (Obrigatório)
Criar interface CardHashKey como tipo de retorno da função cardHashKey

## Link / Imagem para referencias (Obrigatório)
A interface implementa a resposta especificada em "[gerando-uma-nova-chave-para-encriptacao](https://docs.pagar.me/reference#gerando-uma-nova-chave-para-encripta%C3%A7%C3%A3o-do-card_hash)" 