### PR TITLE
fix: make Address.complementary non mandatory

### DIFF
--- a/src/common/Address.ts
+++ b/src/common/Address.ts
@@ -14,5 +14,5 @@ export interface Address {
   /** Bairro */
   neighborhood?: string;
   /** Complemento. **Não pode ser uma string vazia** nem null */
-  complementary: string;
+  complementary?: string;
 }


### PR DESCRIPTION
## O que esse PR faz? (Obrigatório)
torna o campo `complimentary` da interface `Address` opcional

## Link / Imagem para referencias (Obrigatório)
O campo `complimentary` de `Address`  não é mandatório, de acordo com a [documentação](https://docs.pagar.me/reference#objeto-address-endere%C3%A7o) 