### PR TITLE
fix: add comment to CustomerCreateOptions' external_id field

### DIFF
--- a/src/client/customers/options.ts
+++ b/src/client/customers/options.ts
@@ -3,6 +3,7 @@ import { Document } from '../../common/Document';
 import { CustomerType } from '../../common/CustomerType';
 
 export interface CustomerCreateOptions {
+  /** Identificador do cliente em sua plataforma. */
   external_id: string;
   /** Nome ou razão social do comprador */
   name: string;


### PR DESCRIPTION
## O que esse PR faz? (Obrigatório)
add comment to CustomerCreateOptions' external_id field

## Link / Imagem para referencias (Obrigatório)
em [criar-transacao](https://docs.pagar.me/reference#criar-transacao) vemos a especificação do campo `external_id`