### PR TITLE
fix: Customer interface

### DIFF
--- a/src/client/customers/options.ts
+++ b/src/client/customers/options.ts
@@ -16,6 +16,6 @@ export interface CustomerCreateOptions {
   documents: Document[];
   /** Números de telefone. Requer ao menos um valor. Deve seguir o padrão *E.164* */
   phone_numbers: string[];
-  /** Data de nascimento */
-  birthday?: string;
+  /** Data de nascimento. */
+  birthday?: string | null;
 }

--- a/src/client/customers/responses.ts
+++ b/src/client/customers/responses.ts
@@ -2,8 +2,20 @@ import { CustomerCreateOptions } from './options';
 import { Address } from '../../common/Address';
 
 export interface Customer extends CustomerCreateOptions {
+  /** Tipo do objeto */
+  object:  "customer",
   /** Identificador do cliente na loja */
   id: string;
+  /** Número do documento. */
+  document_number: number | null;
+  /** Tipo do documento. */
+  document_type: 'cpf' | 'cnpj' | 'passaport' | 'other' ;
+  /** Local de nascimento. */
+  born_at: string | null;
+  /** Gênero */
+  gender: string | null;
+  /** Quando o customer foi criado */
+  date_created: string;
   /** Lista dos telefones relacionados ao cliente */
   phones: string[];
   /** Lista de endereços relacionados ao cliente */

--- a/src/common/Document.ts
+++ b/src/common/Document.ts
@@ -1,5 +1,7 @@
 export interface Document {
+  /** tipo do objeto */
   object?: "document",
+  /** id relacionada ao documento */
   id?: "string",
   /**
    * Tipo de documento.

--- a/src/common/Document.ts
+++ b/src/common/Document.ts
@@ -1,4 +1,6 @@
 export interface Document {
+  object?: "document",
+  id?: "string",
   /**
    * Tipo de documento.
    *


### PR DESCRIPTION
## O que esse PR faz? (Obrigatório)
Add missing fields to Customer and Document interfaces. Hotfix CustomerCreateOptions.
## Link / Imagem para referencias (Obrigatório)

At "[criando-um-cliente](https://docs.pagar.me/reference#criando-um-cliente)" there are more fields in the customer response than were specified in the Customer interface. Moreover, Document interface is missing `object` and `id` fields which are present in response to customer creation. Finally, `birthday` field in CustomerCreateOptions may be null in response if a birthday is not specified during customer creation.