### PR TITLE
remove 'opts' argument from cards functions

### DIFF
--- a/src/client/cards/namespace.ts
+++ b/src/client/cards/namespace.ts
@@ -4,11 +4,11 @@ import {Card} from "./responses";
 declare module 'pagarme' {
   export namespace client {
     export namespace cards {
-      function all(opts: any, pagination: CardAllOptions): Promise<Array<Card>>;
+      function all(pagination: CardAllOptions): Promise<Array<Card>>;
 
-      function create(opts: any, body: CardCreateOptions): Promise<Card>;
+      function create(body: CardCreateOptions): Promise<Card>;
 
-      function find(opts: any, body: CardFindOptions): Promise<Card>;
+      function find(body: CardFindOptions): Promise<Card>;
     }
   }
 }


### PR DESCRIPTION
## O que esse PR faz? (Obrigatório)
remove parametro `opts` de todas funções do namespace `cards`

## Link / Imagem para referencias (Obrigatório)
Apesar da biblioteca padrão do pagarme.js parecer demonstrar que as funções do namespace `card` esperam dois arguments (`opts` e `body`), o parametro `opts` parece ser injetado pela própria biblioteca, não sendo necessário passá-lo manualmente. De fato, fazer isso acarreta em comportamento incorreto das funções. O jeito correto é passar somente `body`, como sugere a documentação de  [criando-um-cartao](https://docs.pagar.me/reference#criando-um-cartao).

Não tive a chance de testar se o mesmo é válido para todas as outras interfaces que tem `opts` e `body` mas acredito que também seja o caso. Se for, seria interessante remover `opts` das demais funções também e, inclusive, redefinir a nomenclatura da package para usar `body` em vez de `options` sempre que possível. Posso abrir um issue sobre isso.