### PR TITLE
fix: TransactionsCreateOptions interface

### DIFF
--- a/src/client/transactions/options/Create/options.ts
+++ b/src/client/transactions/options/Create/options.ts
@@ -22,7 +22,7 @@ interface TransactionCreateOptionsBase {
   capture?: boolean;
   /** Regras de divisão da transação */
   split_rules?: Array<SplitRuleArg>;
-  customer?: Customer | { id: string };
+  customer?: Customer | { id: number };
   /** Obrigatório com o antifraude habilitado. Define os dados de cobrança, como nome e endereço */
   billing?: Billing;
   /** Deve ser preenchido no caso da venda de bem físico (ver objeto items) */


### PR DESCRIPTION
## O que esse PR faz? (Obrigatório)
Muda o tipo do campo `customer`


## Link / Imagem para referencias (Obrigatório)
`id` de um `customer` tem tipo `number`. Referencia [aqui](https://docs.pagar.me/reference#retornando-dados-do-cliente)