### PR TITLE
fix: remove 'opts' and update CardCreateOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ npm install --save-dev pagarme-js-types
 ...
 ```
 
+Or if that doesn't work for you, instead of changing the tsconfig.json file, 
+just create the following file:
+```ts
+// src/@types/pagarme.d.ts
+import 'pagarme-js-types/src/index';
+```
+
 See more in the [handbook](http://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html).
 
 ## 💪 How to contribute

--- a/src/client/cards/options.ts
+++ b/src/client/cards/options.ts
@@ -1,26 +1,31 @@
-export interface CardCreateOptions {
-    /** Número do cartão. */
-    card_number: string;
-    /** Data de expiração do cartão. */
-    card_expiration_date: string;
-    /** Nome no cartão do portador. */
-    card_holder_name: string;
-    /** Código de segurança do cartão. */
-    card_cvv?: string;
-    /** Informações do cliente do card a ser gerado. */
-    customer_id?: number;
-    /** Dados criptografados do cartão */
-    card_hash: string;
-}
+export type CardCreateOptions = {
+  /** Informações do cliente do card a ser gerado. */
+  customer_id?: number;
+} & (
+  | {
+      /** Número do cartão. */
+      card_number: string;
+      /** Data de expiração do cartão. */
+      card_expiration_date: string;
+      /** Nome no cartão do portador. */
+      card_holder_name: string;
+      /** Código de segurança do cartão. */
+      card_cvv?: string;
+    }
+  | {
+      /** Dados criptografados do cartão */
+      card_hash: string;
+    }
+);
 
 export interface CardFindOptions {
-    /** Id do cartão que deseja consultar os dados. */
-    id: string;
+  /** Id do cartão que deseja consultar os dados. */
+  id: string;
 }
 
 export type CardAllOptions = CardFindOptions & {
-    /** Pagination option to get a list of cards. Number of cards in a page */
-    count?: number;
-    /** Pagination option for a list of cards. The page index. */
-    page?: number;
-}
+  /** Pagination option to get a list of cards. Number of cards in a page */
+  count?: number;
+  /** Pagination option for a list of cards. The page index. */
+  page?: number;
+};

--- a/src/client/transactions/namespace.ts
+++ b/src/client/transactions/namespace.ts
@@ -36,6 +36,7 @@ declare module 'pagarme' {
         T extends TransactionFindOptions ? Transaction[] : Transaction
       >;
 
+      function refund(body: TransactionRefundOptions): Promise<Transaction>;
       function refund(
         opts: any,
         body: TransactionRefundOptions

--- a/src/client/transfers/namespace.ts
+++ b/src/client/transfers/namespace.ts
@@ -1,5 +1,9 @@
 import { Transfer } from './responses';
-import { TransferAllOptions, TransferCreateOptions } from './options';
+import { 
+  TransferAllOptions, 
+  TransferCreateOptions, 
+  TransferFindOptions 
+} from './options';
 
 declare module 'pagarme' {
   export namespace client {
@@ -9,7 +13,8 @@ declare module 'pagarme' {
 
       function cancel(opts: any, body: any): any;
       function days(opts: any): any;
-      function find(opts: any, body: any): any;
+      function find(body: TransferFindOptions): any;
+      function find(opts: any, body: TransferFindOptions): any;
       function limits(opts: any, params: any): any;
     }
   }

--- a/src/client/transfers/options.ts
+++ b/src/client/transfers/options.ts
@@ -1,7 +1,7 @@
 export interface TransferCreateOptions {
-  amount: string;
+  amount: number;
   recipientId: string;
-  metaData?: JSON;
+  metaData?: any;
 }
 
 export interface TransferAllOptions {
@@ -13,4 +13,9 @@ export interface TransferAllOptions {
   id?: string;
   date_created?: string;
   created_at?: string;
+}
+
+
+export interface TransferFindOptions {
+  id?: string;
 }


### PR DESCRIPTION
## O que esse PR faz? (Obrigatório)
- Adiciona sobrecarga em dois dos métodos, permitindo ou não informar o parâmetro 'opts'
- Criado TransferFindOptions
- Alterado TransferCreateOptions, pois apesar de o parâmetro ser um JSON, na prática, será informado qualquer valor e depois convertido para string (JSON) pela SDK da pargarme.
- Acrescentado no README um novo método de usar esse repositório, pois para mim, é a única forma que funciona.
## Link / Imagem para referências (Obrigatório)
- Acho que para essas melhorias, não têm uma documentação oficial.